### PR TITLE
Fixing triple "}" characters

### DIFF
--- a/templates/tag2.sublime-snippet
+++ b/templates/tag2.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[{{ ${1:$SELECTION} }}]]></content>
+    <content><![CDATA[{{ ${1:$SELECTION} }]]></content>
     <tabTrigger>{</tabTrigger>
     <scope>text.html</scope>
     <description>Django template tag</description>


### PR DESCRIPTION
When someone types "{", sublime text automatically adds a closing bracket; one of the brackets at the end of this snippet should be removed to account for the bracket added by sublime.